### PR TITLE
Conditions to inhibit metrics

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,10 +43,11 @@ extra:
       as to measure the effectiveness of our documentation and whether users
       find what they're searching for. With your consent, you're helping us to
       make our documentation better.
-  generator: false
+    cookies:
+      analytics: Site usage statistics (Mixpanel)
+  generator: false  
   analytics:
     provider: mixpanel
-    name: Mixpanel analytics
     # Project token here is NOT a secret. It's used to identify the project in Mixpanel and is write only
     project_token: 9949d865e3afe70668e198cc55b31299
 markdown_extensions:

--- a/overrides/partials/integrations/analytics/mixpanel.html
+++ b/overrides/partials/integrations/analytics/mixpanel.html
@@ -6,7 +6,8 @@
 <script>
   const projectToken = "{{ config.extra.analytics.project_token }}";
   var consent = __md_get("__consent");
-  // Decide whether or not to execute the tracking script
+
+   // Check for consent and production before triggering web metrics
   if ((consent && consent.analytics) && (window.location.hostname.toLowerCase() === "developer.rubrik.com")) {
     mixpanel.init(projectToken, {
         track_pageview: true,
@@ -15,6 +16,6 @@
         ignore_dnt: false, // Set to true to ignore Do Not Track requests from the user's browser
     });
   } else {
-    console.log("Analytics tracking is disabled.");
+    console.log("Mixpanel metrics disabled.");
   }
 </script>


### PR DESCRIPTION
Adds test to:
- only track for the production site
- prevent tracking if consent not granted