### PR TITLE
consistent 404 page titles

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,7 @@
+---
+title: "404 - Page Not Found"
+---
+
+# 404 - Page Not Found
+
+The page you are looking for does not exist. Check the URL or return to the [homepage](/).

--- a/docs/Rubrik-Security-Cloud-API/index.md
+++ b/docs/Rubrik-Security-Cloud-API/index.md
@@ -5,7 +5,7 @@ title: Rubrik Security Cloud API
 
 ## Getting Started
 
-The Rubrik Security Cloud(RSC) API is GraphQL.
+The Rubrik Security Cloud (RSC) API is GraphQL.
 
 ### GraphQL Features
 1. Single Endpoint - The RSC API endpoint will always be /api/graphql.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,8 @@ extra:
     provider: mixpanel
     # Project token here is NOT a secret. It's used to identify the project in Mixpanel and is write only
     project_token: 9949d865e3afe70668e198cc55b31299
+  static_templates:
+    - 404.html
 markdown_extensions:
   - abbr
   - admonition


### PR DESCRIPTION
This should make any "not found" page have a consistent title so we can sift out errors in pageviews. 

minor typo also fixed