### PR TITLE
Fix missing field selection in QAuth PowerShell samples, add getOrgId sample

### DIFF
--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getConfiguration.ps1
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getConfiguration.ps1
@@ -1,3 +1,8 @@
-$query = New-RscQuery -Gql tprConfiguration
+$query = New-RscQuery -Gql tprConfiguration -AddField `
+    isTprEnabled,`
+    requestTimeoutHours,`
+    reminderHours,`
+    executionMaxTimeoutHours,`
+    staticQuorumRequirement
 $query.Var.orgId = "YOUR_ORG_ID"
 $query.Invoke()

--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.gql
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.gql
@@ -1,0 +1,8 @@
+query GetOrgId {
+  orgsForPrincipal {
+    allOrgs {
+      id
+      name
+    }
+  }
+}

--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.ps1
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.ps1
@@ -1,0 +1,4 @@
+$query = New-RscQuery -Gql orgsForPrincipal -AddField `
+    AllOrgs.Id,`
+    AllOrgs.Name
+$query.Invoke().AllOrgs

--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.sh
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# RSC_TOKEN="YOUR_RSC_ACCESS_TOKEN"
+query="query GetOrgId { orgsForPrincipal { allOrgs { id name } } }"
+
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RSC_TOKEN" \
+  -d "{\"query\": \"$query\"}" \
+  https://example.my.rubrik.com/api/graphql

--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getPolicyDetail.ps1
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getPolicyDetail.ps1
@@ -1,3 +1,10 @@
-$query = New-RscQuery -Gql tprPolicyDetail
+$query = New-RscQuery -Gql tprPolicyDetail -AddField `
+    policyId,`
+    name,`
+    description,`
+    orgId,`
+    policyScope,`
+    quorumRequirement,`
+    createdAt
 $query.Var.tprPolicyId = "YOUR_POLICY_ID"
 $query.Invoke()

--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getRequestDetail.ps1
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getRequestDetail.ps1
@@ -1,3 +1,14 @@
-$query = New-RscQuery -Gql tprRequestDetail
+$query = New-RscQuery -Gql tprRequestDetail -AddField `
+    id,`
+    orgId,`
+    orgName,`
+    status,`
+    createdAt,`
+    updatedAt,`
+    expiresAt,`
+    executionType,`
+    isPotentialLastApprover,`
+    triggeredTprRule,`
+    triggeredTprRules
 $query.Var.tprRequestId = "YOUR_REQUEST_ID"
 $query.Invoke()

--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/listPendingRequests.ps1
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/listPendingRequests.ps1
@@ -1,4 +1,10 @@
-$query = New-RscQuery -Gql tprRequestSummaries
+$query = New-RscQuery -Gql tprRequestSummaries -AddField `
+    Nodes.requestId,`
+    Nodes.orgId,`
+    Nodes.orgName,`
+    Nodes.status,`
+    Nodes.updatedAt,`
+    Nodes.triggeredTprRule
 $filter = New-Object RubrikSecurityCloud.Types.TprRequestFilterInput
 $filter.Statuses = @([RubrikSecurityCloud.Types.TprReqStatus]::PENDING)
 $query.Var.filter = $filter

--- a/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/listPolicies.ps1
+++ b/code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/listPolicies.ps1
@@ -1,2 +1,11 @@
-$query = New-RscQuery -Gql customTprPolicies
+$query = New-RscQuery -Gql customTprPolicies -AddField `
+    Nodes.policyId,`
+    Nodes.policyName,`
+    Nodes.description,`
+    Nodes.orgId,`
+    Nodes.orgName,`
+    Nodes.quorumRequirement,`
+    Nodes.numberOfObjectTypes,`
+    Nodes.numberOfProtectableObjects,`
+    Nodes.actions
 $query.Invoke().Nodes

--- a/docs/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization.md
+++ b/docs/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization.md
@@ -213,6 +213,23 @@ Each policy rule targets an object (or is left unscoped for system-level policie
     --8<-- "code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/deletePolicy.sh"
     ```
 
+### Get your org ID
+
+`tprConfiguration` requires an `orgId`. Use `orgsForPrincipal` to retrieve it — this works with both interactive users and service accounts.
+
+=== "GraphQL"
+    ```graphql
+    --8<-- "code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.gql"
+    ```
+=== "PowerShell SDK"
+    ```powershell
+    --8<-- "code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.ps1"
+    ```
+=== "Shell"
+    ```bash
+    --8<-- "code/Rubrik-Security-Cloud-API/System-Settings/Quorum-Authorization/getOrgId.sh"
+    ```
+
 ### Read org configuration
 
 Returns the current timeout and quorum settings for the organization.


### PR DESCRIPTION
## Summary

- Fixed missing `-AddField` parameters in `getConfiguration`, `getPolicyDetail`, `getRequestDetail`, `listPendingRequests`, and `listPolicies` PowerShell samples — `getConfiguration` was fully broken (zero fields selected), others returned incomplete data
- Added `getOrgId` samples (`.gql`, `.ps1`, `.sh`) using `orgsForPrincipal`, which works with service accounts unlike `currentOrg`
- Added "Get your org ID" section to `Quorum-Authorization.md` before `getConfiguration`, explaining the prerequisite lookup

## Test plan

- [ ] All query samples verified against live RSC API
- [ ] `orgsForPrincipal` confirmed working with service account credentials
- [ ] `tprConfiguration` confirmed returning correct data with org ID from `orgsForPrincipal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)