### PR TITLE
Add Hosts guide, add RBS registration samples for VMware and Nutanix

### DIFF
--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.gql
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.gql
@@ -1,0 +1,17 @@
+query CheckHostDiscovery {
+  physicalHosts(
+    hostRoot: WINDOWS_HOST_ROOT
+    filter: [{ field: NAME, texts: ["sqlserver01.example.com"] }]
+  ) {
+    nodes {
+      id
+      name
+      connectionStatus {
+        connectivity
+      }
+      isMssqlHost
+      numWorkloadDescendants
+      osType
+    }
+  }
+}

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.ps1
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.ps1
@@ -1,0 +1,13 @@
+$query = New-RscQuery -GqlQuery physicalHosts -AddField `
+    Nodes.Id,`
+    Nodes.Name,`
+    Nodes.ConnectionStatus.Connectivity,`
+    Nodes.IsMssqlHost,`
+    Nodes.NumWorkloadDescendants,`
+    Nodes.OsType
+$query.Var.HostRoot = [RubrikSecurityCloud.Types.HostRoot]::WINDOWS_HOST_ROOT
+$nameFilter = New-Object RubrikSecurityCloud.Types.Filter
+$nameFilter.Field = [RubrikSecurityCloud.Types.HierarchySortByField]::NAME
+$nameFilter.Texts = @("sqlserver01.example.com")
+$query.Var.Filter = @($nameFilter)
+$query.Invoke().Nodes

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.sh
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# RSC_TOKEN="YOUR_RSC_ACCESS_TOKEN"
+# HOSTNAME="sqlserver01.example.com"
+
+query='query CheckHostDiscovery($hostname: String!) { physicalHosts(hostRoot: WINDOWS_HOST_ROOT, filter: [{ field: NAME, texts: [$hostname] }]) { nodes { id name connectionStatus { connectivity } isMssqlHost numWorkloadDescendants osType } } }'
+
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RSC_TOKEN" \
+  -d "{\"query\": \"$query\", \"variables\": {\"hostname\": \"$HOSTNAME\"}}" \
+  https://example.my.rubrik.com/api/graphql

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.gql
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.gql
@@ -1,0 +1,22 @@
+mutation RegisterHost {
+  bulkRegisterHostAsync(input: {
+    clusterUuid: "YOUR_CLUSTER_UUID"
+    hosts: [
+      {
+        hostname: "sqlserver01.example.com"
+        hasAgent: true
+      }
+    ]
+  }) {
+    output {
+      items {
+        hostSummary {
+          id
+          hostname
+          status
+          operatingSystem
+        }
+      }
+    }
+  }
+}

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.ps1
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.ps1
@@ -1,0 +1,12 @@
+$mutation = New-RscMutation -GqlQuery bulkRegisterHostAsync -AddField `
+    Output.Items.HostSummary.Id,`
+    Output.Items.HostSummary.Hostname,`
+    Output.Items.HostSummary.Status,`
+    Output.Items.HostSummary.OperatingSystem
+$mutation.Var.Input = New-Object -TypeName RubrikSecurityCloud.Types.BulkRegisterHostAsyncInput
+$mutation.Var.Input.ClusterUuid = "YOUR_CLUSTER_UUID"
+$hostInput = New-Object -TypeName RubrikSecurityCloud.Types.HostRegisterInput
+$hostInput.Hostname = "sqlserver01.example.com"
+$hostInput.HasAgent = $true
+$mutation.Var.Input.Hosts = @($hostInput)
+$mutation.Invoke().Output.Items

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.sh
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# RSC_TOKEN="YOUR_RSC_ACCESS_TOKEN"
+# CLUSTER_UUID="YOUR_CLUSTER_UUID"
+# HOSTNAME="sqlserver01.example.com"
+
+query='mutation RegisterHost($clusterUuid: String!, $hostname: String!) { bulkRegisterHostAsync(input: { clusterUuid: $clusterUuid hosts: [{ hostname: $hostname hasAgent: true }] }) { output { items { hostSummary { id hostname status operatingSystem } } } } }'
+
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RSC_TOKEN" \
+  -d "{\"query\": \"$query\", \"variables\": {\"clusterUuid\": \"$CLUSTER_UUID\", \"hostname\": \"$HOSTNAME\"}}" \
+  https://example.my.rubrik.com/api/graphql

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.gql
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.gql
@@ -1,0 +1,7 @@
+mutation RegisterRbs {
+  registerAgentNutanixVm(input: {
+    id: "YOUR_VM_ID"
+  }) {
+    success
+  }
+}

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.ps1
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.ps1
@@ -1,0 +1,4 @@
+$mutation = New-RscMutation -GqlQuery registerAgentNutanixVm
+$mutation.Var.Input = New-Object -TypeName RubrikSecurityCloud.Types.RegisterAgentNutanixVmInput
+$mutation.Var.Input.Id = "YOUR_VM_ID"
+$mutation.Invoke()

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.sh
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# RSC_TOKEN="YOUR_RSC_ACCESS_TOKEN"
+# VM_ID="YOUR_VM_ID"
+query="mutation { registerAgentNutanixVm(input: { id: \\\"$VM_ID\\\" }) { success } }"
+
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RSC_TOKEN" \
+  -d "{\"query\": \"$query\"}" \
+  https://example.my.rubrik.com/api/graphql

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.gql
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.gql
@@ -1,0 +1,7 @@
+mutation RegisterRbs {
+  vsphereVmRegisterAgent(input: {
+    id: "YOUR_VM_ID"
+  }) {
+    success
+  }
+}

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.ps1
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.ps1
@@ -1,0 +1,4 @@
+$mutation = New-RscMutation -GqlQuery vsphereVmRegisterAgent
+$mutation.Var.Input = New-Object -TypeName RubrikSecurityCloud.Types.VsphereVmRegisterAgentInput
+$mutation.Var.Input.Id = "YOUR_VM_ID"
+$mutation.Invoke()

--- a/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.sh
+++ b/code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# RSC_TOKEN="YOUR_RSC_ACCESS_TOKEN"
+# VM_ID="YOUR_VM_ID"
+query="mutation { vsphereVmRegisterAgent(input: { id: \\\"$VM_ID\\\" }) { success } }"
+
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $RSC_TOKEN" \
+  -d "{\"query\": \"$query\"}" \
+  https://example.my.rubrik.com/api/graphql

--- a/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts.md
+++ b/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts.md
@@ -1,0 +1,57 @@
+---
+title: Hosts
+---
+
+# Hosts
+
+Before Rubrik can discover and protect workloads on a Windows or Linux physical server, the host must be registered with the Rubrik cluster. Registration initiates background discovery of installed software — for SQL Server hosts, this discovers instances and databases automatically.
+
+!!! note
+    If you're registering RBS on a VMware vSphere VM, see [VMware vSphere](VMware-vSphere.md#register-rbs-on-a-vm). For Nutanix AHV VMs, see [Nutanix AHV](Nutanix-AHV.md#register-rbs-on-a-vm).
+
+## Prerequisites
+
+- **Rubrik Backup Service (RBS)** must be installed on the host before registration. Download the installer from your Rubrik cluster UI under **Settings > Data Sources > Connectors**.
+- You'll need the **cluster UUID** of the Rubrik cluster that will manage this host. Find it in the RSC UI under **Rubrik Clusters**, or from the `clusterUuid` field returned by any cluster query.
+
+## Register a Host
+
+Use `bulkRegisterHostAsync` to register one or more hosts. The mutation accepts the request and returns immediately; host discovery runs in the background.
+
+=== "GraphQL"
+    ```graphql
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.gql"
+    ```
+=== "PowerShell SDK"
+    ```powershell
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.ps1"
+    ```
+=== "Shell"
+    ```bash
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/registerHost.sh"
+    ```
+
+After the mutation returns, discovery runs in the background. For SQL Server hosts, instances and databases will appear in API queries once discovery completes — typically within a few minutes.
+
+## Verify Discovery
+
+Use `physicalHosts` to confirm the host is registered and discovery has completed. Poll until `connectionStatus.connectivity` is `CONNECTED`.
+
+=== "GraphQL"
+    ```graphql
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.gql"
+    ```
+=== "PowerShell SDK"
+    ```powershell
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.ps1"
+    ```
+=== "Shell"
+    ```bash
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Hosts/checkHostDiscovery.sh"
+    ```
+
+`numWorkloadDescendants` reflects the total number of discovered workloads (SQL instances, databases, filesets). Once this is non-zero, the host is ready for protection. `isMssqlHost` will be `true` once SQL Server instances have been discovered.
+
+## Next Steps
+
+- [Microsoft SQL Server](Microsoft-SQL.md) — configure protection and run backup and recovery operations for SQL Server databases

--- a/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Microsoft-SQL.md
+++ b/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Microsoft-SQL.md
@@ -16,7 +16,7 @@ SLA policies assigned at the host or instance level are inherited by all objects
 
 Before protecting SQL Server databases through the API:
 
-1. **Register your SQL Server host** — See [Host and Connector Setup](Host-Setup.md) to add the Windows host running SQL Server to your Rubrik cluster. Discovery of instances and databases happens automatically after registration.
+1. **Register your SQL Server host** — See [Hosts](Hosts.md) to add the Windows host running SQL Server to your Rubrik cluster. Discovery of instances and databases happens automatically after registration.
 
 2. **Locate your SLA Domain** — See [SLA Domains](../SLA-Domains.md) to retrieve the UUID of the SLA policy you want to apply. You'll need this when assigning protection.
 

--- a/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV.md
+++ b/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV.md
@@ -17,6 +17,23 @@ title: Nutanix AHV
     --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/virtualmachines.sh"
     ```
 
+### Register RBS on a VM
+
+To enable app-consistent backups for workloads running inside a Nutanix VM (such as SQL Server or Oracle), register the Rubrik Backup Service (RBS) after the VM has been discovered. Use the VM's `id` from the retrieval query above.
+
+=== "GraphQL"
+    ```graphql
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.gql"
+    ```
+=== "PowerShell SDK"
+    ```powershell
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.ps1"
+    ```
+=== "Shell"
+    ```bash
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/Nutanix-AHV/registerRbs.sh"
+    ```
+
 ### On-Demand Backup
 === "GraphQL"
     ```graphql

--- a/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere.md
+++ b/docs/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere.md
@@ -16,6 +16,23 @@ title: VMware vSphere
     ```bash
     --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/virtualmachines.sh"
     ```
+### Register RBS on a VM
+
+To enable app-consistent backups for workloads running inside a vSphere VM (such as SQL Server or Oracle), register the Rubrik Backup Service (RBS) after the VM has been discovered. Use the VM's `id` from the retrieval query above.
+
+=== "GraphQL"
+    ```graphql
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.gql"
+    ```
+=== "PowerShell SDK"
+    ```powershell
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.ps1"
+    ```
+=== "Shell"
+    ```bash
+    --8<-- "code/Rubrik-Security-Cloud-API/Data-Protection/Data-Center/VMware-vSphere/registerRbs.sh"
+    ```
+
 ### On-Demand Backup
 === "GraphQL"
     ```graphql


### PR DESCRIPTION
## Summary

- Renames `Host-Setup` → `Hosts` (doc and code directory) to better reflect the broader scope
- Adds cross-reference note pointing VMware/Nutanix users to their respective pages for RBS registration
- Adds `registerRbs` samples (`.gql`, `.ps1`, `.sh`) to VMware vSphere and Nutanix AHV pages using `vsphereVmRegisterAgent` and `registerAgentNutanixVm`
- Adds `checkHostDiscovery` samples using `physicalHosts` to verify registration completed
- Updates Microsoft SQL Server prerequisite link to point to `Hosts.md`

## Test plan

- [ ] `vsphereVmRegisterAgent` and `registerAgentNutanixVm` signatures verified against live RSC schema
- [ ] `physicalHosts` query syntax verified against live RSC API
- [ ] All code path references updated from `Host-Setup/` to `Hosts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)